### PR TITLE
Enabling multiple FK on one table

### DIFF
--- a/src/MicroOrm.Dapper.Repositories/Attributes/Joins/InnerJoinAttribute.cs
+++ b/src/MicroOrm.Dapper.Repositories/Attributes/Joins/InnerJoinAttribute.cs
@@ -19,7 +19,7 @@
         /// <param name="key">ForeignKey of this table</param>
         /// <param name="externalKey">Key of external table</param>
         public InnerJoinAttribute(string tableName, string key, string externalKey)
-            : base(tableName, key, externalKey, string.Empty)
+            : base(tableName, key, externalKey, string.Empty, string.Empty)
         {
         }
 
@@ -31,7 +31,20 @@
         /// <param name="externalKey">Key of external table</param>
         /// <param name="tableSchema">Name of external table schema</param>
         public InnerJoinAttribute(string tableName, string key, string externalKey, string tableSchema)
-            : base(tableName, key, externalKey, tableSchema)
+            : base(tableName, key, externalKey, tableSchema, string.Empty)
+        {
+        }
+
+        /// <summary>
+        ///     Constructor
+        /// </summary>
+        /// <param name="tableName">Name of external table</param>
+        /// <param name="key">ForeignKey of this table</param>
+        /// <param name="externalKey">Key of external table</param>
+        /// <param name="tableSchema">Name of external table schema</param>
+        /// <param name="tableAbbreviation">External table alias</param>
+        public InnerJoinAttribute(string tableName, string key, string externalKey, string tableSchema, string tableAbbreviation)
+            : base(tableName, key, externalKey, tableSchema, tableAbbreviation)
         {
         }
     }

--- a/src/MicroOrm.Dapper.Repositories/Attributes/Joins/JoinAttributeBase.cs
+++ b/src/MicroOrm.Dapper.Repositories/Attributes/Joins/JoinAttributeBase.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace MicroOrm.Dapper.Repositories.Attributes.Joins
 {
@@ -17,12 +19,18 @@ namespace MicroOrm.Dapper.Repositories.Attributes.Joins
         /// <summary>
         ///     Constructor
         /// </summary>
-        protected JoinAttributeBase(string tableName, string key, string externalKey, string tableSchema)
+        protected JoinAttributeBase(string tableName, string key, string externalKey, string tableSchema, string tableAlias)
         {
             TableName = tableName;
             Key = key;
             ExternalKey = externalKey;
             TableSchema = tableSchema;
+            TableAlias = tableAlias == string.Empty ? GetAlias() : tableAlias;
+        }
+
+        private string GetAlias()
+        {
+            return $"{TableName}_{Key}";
         }
 
         /// <summary>
@@ -44,5 +52,10 @@ namespace MicroOrm.Dapper.Repositories.Attributes.Joins
         ///     Key of external table
         /// </summary>
         public string ExternalKey { get; set; }
+
+        /// <summary>
+        ///     Table abbreviation override
+        /// </summary>
+        public string TableAlias { get; set; }
     }
 }

--- a/src/MicroOrm.Dapper.Repositories/Attributes/Joins/LeftJoinAttribute.cs
+++ b/src/MicroOrm.Dapper.Repositories/Attributes/Joins/LeftJoinAttribute.cs
@@ -19,7 +19,7 @@
         /// <param name="key">ForeignKey of this table</param>
         /// <param name="externalKey">Key of external table</param>
         public LeftJoinAttribute(string tableName, string key, string externalKey)
-            : base(tableName, key, externalKey, string.Empty)
+            : base(tableName, key, externalKey, string.Empty, string.Empty)
         {
         }
 
@@ -31,7 +31,20 @@
         /// <param name="externalKey">Key of external table</param>
         /// <param name="tableSchema">Name of external table schema</param>
         public LeftJoinAttribute(string tableName, string key, string externalKey, string tableSchema)
-            : base(tableName, key, externalKey, tableSchema)
+            : base(tableName, key, externalKey, tableSchema, string.Empty)
+        {
+        }
+
+        /// <summary>
+        ///     Constructor
+        /// </summary>
+        /// <param name="tableName">Name of external table</param>
+        /// <param name="key">ForeignKey of this table</param>
+        /// <param name="externalKey">Key of external table</param>
+        /// <param name="tableSchema">Name of external table schema</param>
+        /// <param name="tableAbbreviation">External table alias</param>
+        public LeftJoinAttribute(string tableName, string key, string externalKey, string tableSchema, string tableAbbreviation)
+            : base(tableName, key, externalKey, tableSchema, tableAbbreviation)
         {
         }
     }

--- a/src/MicroOrm.Dapper.Repositories/Attributes/Joins/RightJoinAttribute.cs
+++ b/src/MicroOrm.Dapper.Repositories/Attributes/Joins/RightJoinAttribute.cs
@@ -19,7 +19,7 @@
         /// <param name="key">ForeignKey of this table</param>
         /// <param name="externalKey">Key of external table</param>
         public RightJoinAttribute(string tableName, string key, string externalKey)
-            : base(tableName, key, externalKey, string.Empty)
+            : base(tableName, key, externalKey, string.Empty, string.Empty)
         {
         }
 
@@ -31,7 +31,20 @@
         /// <param name="externalKey">Key of external table</param>
         /// <param name="tableSchema">Name of external table schema</param>
         public RightJoinAttribute(string tableName, string key, string externalKey, string tableSchema)
-            : base(tableName, key, externalKey, tableSchema)
+            : base(tableName, key, externalKey, tableSchema, string.Empty)
+        {
+        }
+
+        /// <summary>
+        ///     Constructor
+        /// </summary>
+        /// <param name="tableName">Name of external table</param>
+        /// <param name="key">ForeignKey of this table</param>
+        /// <param name="externalKey">Key of external table</param>
+        /// <param name="tableSchema">Name of external table schema</param>
+        /// <param name="tableAbbreviation">External table alias</param>
+        public RightJoinAttribute(string tableName, string key, string externalKey, string tableSchema, string tableAbbreviation)
+            : base(tableName, key, externalKey, tableSchema, tableAbbreviation)
         {
         }
     }

--- a/src/MicroOrm.Dapper.Repositories/SqlGenerator/SqlGenerator.cs
+++ b/src/MicroOrm.Dapper.Repositories/SqlGenerator/SqlGenerator.cs
@@ -368,7 +368,7 @@ namespace MicroOrm.Dapper.Repositories.SqlGenerator
                     if (item.NestedProperty)
                     {
                         var joinProperty = SqlJoinProperties.First(x => x.PropertyName == item.PropertyName);
-                        tableName = joinProperty.TableName;
+                        tableName = joinProperty.TableAlias;
                         columnName = joinProperty.ColumnName;
                     }
                     else
@@ -484,6 +484,7 @@ namespace MicroOrm.Dapper.Repositories.SqlGenerator
                         {
                             propertyMetadata.TableName = GetTableNameWithSchemaPrefix(propertyMetadata.TableName, propertyMetadata.TableSchema, "[", "]");
                             propertyMetadata.ColumnName = "[" + propertyMetadata.ColumnName + "]";
+                            propertyMetadata.TableAlias = "[" + propertyMetadata.TableAlias + "]";
                         }
 
                         if (IdentitySqlProperty != null)
@@ -504,6 +505,7 @@ namespace MicroOrm.Dapper.Repositories.SqlGenerator
                         {
                             propertyMetadata.TableName = GetTableNameWithSchemaPrefix(propertyMetadata.TableName, propertyMetadata.TableSchema, "`", "`");
                             propertyMetadata.ColumnName = "`" + propertyMetadata.ColumnName + "`";
+                            propertyMetadata.TableAlias = "`" + propertyMetadata.TableAlias + "`";
                         }
 
                         if (IdentitySqlProperty != null)
@@ -524,6 +526,7 @@ namespace MicroOrm.Dapper.Repositories.SqlGenerator
                         {
                             propertyMetadata.TableName = GetTableNameWithSchemaPrefix(propertyMetadata.TableName, propertyMetadata.TableSchema, "\"", "\"");
                             propertyMetadata.ColumnName = "\"" + propertyMetadata.ColumnName + "\"";
+                            propertyMetadata.TableAlias = "\"" + propertyMetadata.TableAlias + "\"";
                         }
 
                         if (IdentitySqlProperty != null)
@@ -625,6 +628,7 @@ namespace MicroOrm.Dapper.Repositories.SqlGenerator
                             attrJoin.TableName = GetTableNameWithSchemaPrefix(attrJoin.TableName, attrJoin.TableSchema, "[", "]");
                             attrJoin.Key = "[" + attrJoin.Key + "]";
                             attrJoin.ExternalKey = "[" + attrJoin.ExternalKey + "]";
+                            attrJoin.TableAlias = "[" + attrJoin.TableAlias + "]";
                             foreach (var prop in props)
                                 prop.ColumnName = "[" + prop.ColumnName + "]";
                             break;
@@ -634,6 +638,7 @@ namespace MicroOrm.Dapper.Repositories.SqlGenerator
                             attrJoin.TableName = GetTableNameWithSchemaPrefix(attrJoin.TableName, attrJoin.TableSchema, "`", "`");
                             attrJoin.Key = "`" + attrJoin.Key + "`";
                             attrJoin.ExternalKey = "`" + attrJoin.ExternalKey + "`";
+                            attrJoin.TableAlias = "`" + attrJoin.TableAlias + "`";
                             foreach (var prop in props)
                                 prop.ColumnName = "`" + prop.ColumnName + "`";
                             break;
@@ -643,6 +648,7 @@ namespace MicroOrm.Dapper.Repositories.SqlGenerator
                             attrJoin.TableName = GetTableNameWithSchemaPrefix(attrJoin.TableName, attrJoin.TableSchema, "\"", "\"");
                             attrJoin.Key = "\"" + attrJoin.Key + "\"";
                             attrJoin.ExternalKey = "\"" + attrJoin.ExternalKey + "\"";
+                            attrJoin.TableAlias = "\"" + attrJoin.TableAlias + "\"";
                             foreach (var prop in props)
                                 prop.ColumnName = "\"" + prop.ColumnName + "\"";
                             break;
@@ -653,8 +659,9 @@ namespace MicroOrm.Dapper.Repositories.SqlGenerator
                 else
                     attrJoin.TableName = GetTableNameWithSchemaPrefix(attrJoin.TableName, attrJoin.TableSchema);
 
-                originalBuilder.SqlBuilder.Append(", " + GetFieldsSelect(attrJoin.TableName, props));
-                joinBuilder.Append(joinString + " " + attrJoin.TableName + " ON " + tableName + "." + attrJoin.Key + " = " + attrJoin.TableName + "." + attrJoin.ExternalKey + " ");
+                originalBuilder.SqlBuilder.Append($", {GetFieldsSelect(attrJoin.TableAlias, props)}");
+                joinBuilder.Append($"{joinString} {attrJoin.TableName} AS {attrJoin.TableAlias} ON {tableName}.{attrJoin.Key} = {attrJoin.TableAlias}.{attrJoin.ExternalKey} ");
+                
             }
             return joinBuilder.ToString();
         }

--- a/src/MicroOrm.Dapper.Repositories/SqlGenerator/SqlJoinPropertyMetadata.cs
+++ b/src/MicroOrm.Dapper.Repositories/SqlGenerator/SqlJoinPropertyMetadata.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using MicroOrm.Dapper.Repositories.Attributes.Joins;
+using System;
 
 namespace MicroOrm.Dapper.Repositories.SqlGenerator
 {
@@ -19,12 +20,18 @@ namespace MicroOrm.Dapper.Repositories.SqlGenerator
             JoinPropertyInfo = joinPropertyInfo;
             TableSchema = joinAtttribute.TableSchema;
             TableName = joinAtttribute.TableName;
+            TableAlias = joinAtttribute.TableAlias;
         }
 
         /// <summary>
         ///     Table name
         /// </summary>
         public string TableName { get; set; }
+
+        /// <summary>
+        ///     Table alias
+        /// </summary>
+        public string TableAlias { get; set; }
 
         /// <summary>
         ///     Schema name

--- a/test/MicroOrm.Dapper.Repositories.Tests/Classes/User.cs
+++ b/test/MicroOrm.Dapper.Repositories.Tests/Classes/User.cs
@@ -24,6 +24,8 @@ namespace MicroOrm.Dapper.Repositories.Tests.Classes
 
         public int PhoneId { get; set; }
 
+        public int OfficePhoneId { get; set; }
+
         [LeftJoin("Cars", "Id", "UserId")]
         public List<Car> Cars { get; set; }
 
@@ -32,6 +34,9 @@ namespace MicroOrm.Dapper.Repositories.Tests.Classes
 
         [InnerJoin("Phones", "PhoneId", "Id", "DAB")]
         public Phone Phone { get; set; }
+
+        [InnerJoin("Phones", "OfficePhoneId", "Id", "DAB")]
+        public Phone OfficePhone { get; set; }
 
         [Status]
         [Deleted]

--- a/test/MicroOrm.Dapper.Repositories.Tests/DatabaseFixture/MsSqlDatabaseFixture.cs
+++ b/test/MicroOrm.Dapper.Repositories.Tests/DatabaseFixture/MsSqlDatabaseFixture.cs
@@ -53,7 +53,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.DatabaseFixture
 
             CreateSchema("DAB");
 
-            Db.Connection.Execute(@"CREATE TABLE Users (Id int IDENTITY(1,1) not null, Name varchar(256) not null, AddressId int not null, PhoneId int not null, Deleted bit not null, UpdatedAt datetime2,  PRIMARY KEY (Id))");
+            Db.Connection.Execute(@"CREATE TABLE Users (Id int IDENTITY(1,1) not null, Name varchar(256) not null, AddressId int not null, PhoneId int not null, OfficePhoneId int not null, Deleted bit not null, UpdatedAt datetime2,  PRIMARY KEY (Id))");
             Db.Connection.Execute(@"CREATE TABLE Cars (Id int IDENTITY(1,1) not null, Name varchar(256) not null, UserId int not null, Status int not null, Data binary(16) null, PRIMARY KEY (Id))");
 
             Db.Connection.Execute(@"CREATE TABLE Addresses (Id int IDENTITY(1,1) not null, Street varchar(256) not null, CityId varchar(256) not null,  PRIMARY KEY (Id))");
@@ -71,7 +71,8 @@ namespace MicroOrm.Dapper.Repositories.Tests.DatabaseFixture
                 {
                     Name = $"TestName{i}",
                     AddressId = 1,
-                    PhoneId = 1
+                    PhoneId = 1,
+                    OfficePhoneId = 2
                 });
 
             Db.Users.Insert(new User { Name = "TestName0", PhoneId = 1 });

--- a/test/MicroOrm.Dapper.Repositories.Tests/RepositoriesTests/MsSqlRepositoriesTests.cs
+++ b/test/MicroOrm.Dapper.Repositories.Tests/RepositoriesTests/MsSqlRepositoriesTests.cs
@@ -171,6 +171,26 @@ namespace MicroOrm.Dapper.Repositories.Tests.RepositoriesTests
         }
 
         [Fact]
+        public void FindAllJoinSameTableTwice()
+        {
+            var user = _sqlDatabaseFixture.Db.Users.FindAll<Phone, Car, Phone>(x => x.Id == 1, q => q.OfficePhone, q => q.Cars, q => q.Phone).First();
+            Assert.True(user.Cars.Count == 1);
+            Assert.Equal("TestCar0", user.Cars.First().Name);
+            Assert.Equal("333", user.OfficePhone.Number);
+            Assert.Equal("123", user.Phone.Number);
+        }
+
+        [Fact]
+        public async void FindAllJoinSameTableTwiceAsync()
+        {
+            var user = (await _sqlDatabaseFixture.Db.Users.FindAllAsync<Phone, Car, Phone>(x => x.Id == 1, q => q.OfficePhone, q => q.Cars, q => q.Phone)).First();
+            Assert.True(user.Cars.Count == 1);
+            Assert.Equal("TestCar0", user.Cars.First().Name);
+            Assert.Equal("333", user.OfficePhone.Number);
+            Assert.Equal("123", user.Phone.Number);
+        }
+
+        [Fact]
         public async Task FindAsync()
         {
             const int id = 4;

--- a/test/MicroOrm.Dapper.Repositories.Tests/SqlGeneratorTests/MsSqlGeneratorTests.cs
+++ b/test/MicroOrm.Dapper.Repositories.Tests/SqlGeneratorTests/MsSqlGeneratorTests.cs
@@ -157,7 +157,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             var ids = new List<int>();
             var sqlQuery = userSqlGenerator.GetSelectAll(x => ids.Contains(x.Id));
 
-            Assert.Equal("SELECT [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[Deleted], [Users].[UpdatedAt] " +
+            Assert.Equal("SELECT [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[OfficePhoneId], [Users].[Deleted], [Users].[UpdatedAt] " +
                          "FROM [Users] WHERE [Users].[Id] IN @Id AND [Users].[Deleted] != 1", sqlQuery.GetSql());
         }
 
@@ -249,7 +249,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             ISqlGenerator<User> userSqlGenerator = new SqlGenerator<User>(SqlConnector, true);
             var sqlQuery = userSqlGenerator.GetSelectAll(user => user.UpdatedAt == null);
 
-            Assert.Equal("SELECT [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[Deleted], [Users].[UpdatedAt] FROM [Users] " +
+            Assert.Equal("SELECT [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[OfficePhoneId], [Users].[Deleted], [Users].[UpdatedAt] FROM [Users] " +
                          "WHERE [Users].[UpdatedAt] IS NULL AND [Users].[Deleted] != 1", sqlQuery.GetSql());
             Assert.DoesNotContain("== NULL", sqlQuery.GetSql());
         }
@@ -260,9 +260,9 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             ISqlGenerator<User> userSqlGenerator = new SqlGenerator<User>(SqlConnector, true);
             var sqlQuery = userSqlGenerator.GetSelectAll(null, user => user.Cars);
 
-            Assert.Equal("SELECT [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[Deleted], [Users].[UpdatedAt], " +
-                         "[Cars].[Id], [Cars].[Name], [Cars].[Data], [Cars].[UserId], [Cars].[Status] " +
-                         "FROM [Users] LEFT JOIN [Cars] ON [Users].[Id] = [Cars].[UserId] " +
+            Assert.Equal("SELECT [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[OfficePhoneId], [Users].[Deleted], [Users].[UpdatedAt], " +
+                         "[Cars_Id].[Id], [Cars_Id].[Name], [Cars_Id].[Data], [Cars_Id].[UserId], [Cars_Id].[Status] " +
+                         "FROM [Users] LEFT JOIN [Cars] AS [Cars_Id] ON [Users].[Id] = [Cars_Id].[UserId] " +
                          "WHERE [Users].[Deleted] != 1", sqlQuery.GetSql());
         }
 
@@ -272,10 +272,10 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             ISqlGenerator<User> userSqlGenerator = new SqlGenerator<User>(SqlConnector, true);
             var sqlQuery = userSqlGenerator.GetSelectFirst(x => x.Phone.Number == "123", user => user.Phone);
 
-            Assert.Equal("SELECT TOP 1 [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[Deleted], [Users].[UpdatedAt], " +
-                         "[DAB].[Phones].[Id], [DAB].[Phones].[Number], [DAB].[Phones].[IsActive], [DAB].[Phones].[Code] " +
-                         "FROM [Users] INNER JOIN [DAB].[Phones] ON [Users].[PhoneId] = [DAB].[Phones].[Id] " +
-                         "WHERE [DAB].[Phones].[Number] = @PhoneNumber AND [Users].[Deleted] != 1", sqlQuery.GetSql());
+            Assert.Equal("SELECT TOP 1 [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[OfficePhoneId], [Users].[Deleted], [Users].[UpdatedAt], " +
+                         "[Phones_PhoneId].[Id], [Phones_PhoneId].[Number], [Phones_PhoneId].[IsActive], [Phones_PhoneId].[Code] " +
+                         "FROM [Users] INNER JOIN [DAB].[Phones] AS [Phones_PhoneId] ON [Users].[PhoneId] = [Phones_PhoneId].[Id] " +
+                         "WHERE [Phones_PhoneId].[Number] = @PhoneNumber AND [Users].[Deleted] != 1", sqlQuery.GetSql());
         }
 
         [Fact]
@@ -284,10 +284,10 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             ISqlGenerator<User> userSqlGenerator = new SqlGenerator<User>(SqlConnector, false);
             var sqlQuery = userSqlGenerator.GetSelectFirst(x => x.Phone.Number == "123", user => user.Phone);
 
-            Assert.Equal("SELECT TOP 1 Users.Id, Users.Name, Users.AddressId, Users.PhoneId, Users.Deleted, Users.UpdatedAt, " +
-                         "DAB.Phones.Id, DAB.Phones.Number, DAB.Phones.IsActive, DAB.Phones.Code " +
-                         "FROM Users INNER JOIN DAB.Phones ON Users.PhoneId = DAB.Phones.Id " +
-                         "WHERE DAB.Phones.Number = @PhoneNumber AND Users.Deleted != 1", sqlQuery.GetSql());
+            Assert.Equal("SELECT TOP 1 Users.Id, Users.Name, Users.AddressId, Users.PhoneId, Users.OfficePhoneId, Users.Deleted, Users.UpdatedAt, " +
+                         "Phones_PhoneId.Id, Phones_PhoneId.Number, Phones_PhoneId.IsActive, Phones_PhoneId.Code " +
+                         "FROM Users INNER JOIN DAB.Phones AS Phones_PhoneId ON Users.PhoneId = Phones_PhoneId.Id " +
+                         "WHERE Phones_PhoneId.Number = @PhoneNumber AND Users.Deleted != 1", sqlQuery.GetSql());
         }
 
 
@@ -297,7 +297,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             ISqlGenerator<User> userSqlGenerator = new SqlGenerator<User>(SqlConnector, false);
             var sqlQuery = userSqlGenerator.GetSelectBetween(1, 10, x => x.Id);
 
-            Assert.Equal("SELECT Users.Id, Users.Name, Users.AddressId, Users.PhoneId, Users.Deleted, Users.UpdatedAt FROM Users " +
+            Assert.Equal("SELECT Users.Id, Users.Name, Users.AddressId, Users.PhoneId, Users.OfficePhoneId, Users.Deleted, Users.UpdatedAt FROM Users " +
                          "WHERE Users.Deleted != 1 AND Users.Id BETWEEN '1' AND '10'", sqlQuery.GetSql());
         }
 
@@ -307,7 +307,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             ISqlGenerator<User> userSqlGenerator = new SqlGenerator<User>(SqlConnector, true);
             var sqlQuery = userSqlGenerator.GetSelectBetween(1, 10, x => x.Id);
 
-            Assert.Equal("SELECT [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[Deleted], [Users].[UpdatedAt] FROM [Users] " +
+            Assert.Equal("SELECT [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[OfficePhoneId], [Users].[Deleted], [Users].[UpdatedAt] FROM [Users] " +
                          "WHERE [Users].[Deleted] != 1 AND [Users].[Id] BETWEEN '1' AND '10'", sqlQuery.GetSql());
         }
 
@@ -338,7 +338,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             ISqlGenerator<User> userSqlGenerator = new SqlGenerator<User>(SqlConnector, true);
             var sqlQuery = userSqlGenerator.GetSelectById(1);
 
-            Assert.Equal("SELECT TOP 1 [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[Deleted], [Users].[UpdatedAt] " +
+            Assert.Equal("SELECT TOP 1 [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[OfficePhoneId], [Users].[Deleted], [Users].[UpdatedAt] " +
                          "FROM [Users] WHERE [Users].[Id] = @Id AND [Users].[Deleted] != 1", sqlQuery.GetSql());
         }
 
@@ -347,7 +347,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
         {
             ISqlGenerator<User> userSqlGenerator = new SqlGenerator<User>(SqlConnector, true);
             var sqlQuery = userSqlGenerator.GetSelectFirst(x => x.Id == 2);
-            Assert.Equal("SELECT TOP 1 [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[Deleted], [Users].[UpdatedAt] FROM [Users] WHERE [Users].[Id] = @Id AND [Users].[Deleted] != 1", sqlQuery.GetSql());
+            Assert.Equal("SELECT TOP 1 [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[OfficePhoneId], [Users].[Deleted], [Users].[UpdatedAt] FROM [Users] WHERE [Users].[Id] = @Id AND [Users].[Deleted] != 1", sqlQuery.GetSql());
         }
 
         [Fact]

--- a/test/MicroOrm.Dapper.Repositories.Tests/SqlGeneratorTests/MySqlGeneratorTests.cs
+++ b/test/MicroOrm.Dapper.Repositories.Tests/SqlGeneratorTests/MySqlGeneratorTests.cs
@@ -57,7 +57,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             ISqlGenerator<User> userSqlGenerator = new SqlGenerator<User>(SqlConnector, true);
             var sqlQuery = userSqlGenerator.GetSelectAll(user => user.UpdatedAt != null);
 
-            Assert.Equal("SELECT `Users`.`Id`, `Users`.`Name`, `Users`.`AddressId`, `Users`.`PhoneId`, `Users`.`Deleted`, `Users`.`UpdatedAt` FROM `Users` " +
+            Assert.Equal("SELECT `Users`.`Id`, `Users`.`Name`, `Users`.`AddressId`, `Users`.`PhoneId`, `Users`.`OfficePhoneId`, `Users`.`Deleted`, `Users`.`UpdatedAt` FROM `Users` " +
                          "WHERE `Users`.`UpdatedAt` IS NOT NULL AND `Users`.`Deleted` != 1", sqlQuery.GetSql());
             Assert.DoesNotContain("!= NULL", sqlQuery.GetSql());
         }
@@ -69,12 +69,12 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             ISqlGenerator<User> userSqlGenerator = new SqlGenerator<User>(SqlConnector, true);
             var sqlQuery = userSqlGenerator.GetSelectAll(user => user.Name == "Frank" && user.UpdatedAt != null);
 
-            Assert.Equal("SELECT `Users`.`Id`, `Users`.`Name`, `Users`.`AddressId`, `Users`.`PhoneId`, `Users`.`Deleted`, `Users`.`UpdatedAt` FROM `Users` " +
+            Assert.Equal("SELECT `Users`.`Id`, `Users`.`Name`, `Users`.`AddressId`, `Users`.`PhoneId`, `Users`.`OfficePhoneId`, `Users`.`Deleted`, `Users`.`UpdatedAt` FROM `Users` " +
                          "WHERE `Users`.`Name` = @Name AND `Users`.`UpdatedAt` IS NOT NULL AND `Users`.`Deleted` != 1", sqlQuery.GetSql());
             Assert.DoesNotContain("!= NULL", sqlQuery.GetSql());
 
             sqlQuery = userSqlGenerator.GetSelectAll(user => user.UpdatedAt != null && user.Name == "Frank");
-            Assert.Equal("SELECT `Users`.`Id`, `Users`.`Name`, `Users`.`AddressId`, `Users`.`PhoneId`, `Users`.`Deleted`, `Users`.`UpdatedAt` FROM `Users` " +
+            Assert.Equal("SELECT `Users`.`Id`, `Users`.`Name`, `Users`.`AddressId`, `Users`.`PhoneId`, `Users`.`OfficePhoneId`, `Users`.`Deleted`, `Users`.`UpdatedAt` FROM `Users` " +
                          "WHERE `Users`.`UpdatedAt` IS NOT NULL AND `Users`.`Name` = @Name AND `Users`.`Deleted` != 1", sqlQuery.GetSql());
             Assert.DoesNotContain("!= NULL", sqlQuery.GetSql());
         }
@@ -86,7 +86,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             ISqlGenerator<User> userSqlGenerator = new SqlGenerator<User>(SqlConnector, true);
             var sqlQuery = userSqlGenerator.GetSelectBetween(1, 10, x => x.Id);
 
-            Assert.Equal("SELECT `Users`.`Id`, `Users`.`Name`, `Users`.`AddressId`, `Users`.`PhoneId`, `Users`.`Deleted`, `Users`.`UpdatedAt` FROM `Users` " +
+            Assert.Equal("SELECT `Users`.`Id`, `Users`.`Name`, `Users`.`AddressId`, `Users`.`PhoneId`, `Users`.`OfficePhoneId`, `Users`.`Deleted`, `Users`.`UpdatedAt` FROM `Users` " +
                          "WHERE `Users`.`Deleted` != 1 AND `Users`.`Id` BETWEEN '1' AND '10'", sqlQuery.GetSql());
         }
 
@@ -128,7 +128,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
         {
             ISqlGenerator<User> userSqlGenerator = new SqlGenerator<User>(SqlConnector, true);
             var sqlQuery = userSqlGenerator.GetSelectFirst(x => x.Id == 6);
-            Assert.Equal("SELECT `Users`.`Id`, `Users`.`Name`, `Users`.`AddressId`, `Users`.`PhoneId`, `Users`.`Deleted`, `Users`.`UpdatedAt` FROM `Users` WHERE `Users`.`Id` = @Id AND `Users`.`Deleted` != 1 LIMIT 1", sqlQuery.GetSql());
+            Assert.Equal("SELECT `Users`.`Id`, `Users`.`Name`, `Users`.`AddressId`, `Users`.`PhoneId`, `Users`.`OfficePhoneId`, `Users`.`Deleted`, `Users`.`UpdatedAt` FROM `Users` WHERE `Users`.`Id` = @Id AND `Users`.`Deleted` != 1 LIMIT 1", sqlQuery.GetSql());
         }
     }
 }


### PR DESCRIPTION
Related to #64 

Resolving conflicts by adding aliases to joined tables.
There is still corner case if someone will try to create two different FK pointing one table with one key like this:
```
[InnerJoin("Phones", "PhoneId", "Id", "DAB")]
public Phone Phone { get; set; }

[InnerJoin("Phones", "PhoneId", "Id", "DAB")]
public Phone AnotherPhone { get; set; }
```
but I don't think there is any actual value behind such thing.