### PR TITLE
adapts the unary NOT operator (`NOT IN @a` syntax)/Support `group conditions` syntax

### DIFF
--- a/src/MicroOrm.Dapper.Repositories/DapperRepository.Update.cs
+++ b/src/MicroOrm.Dapper.Repositories/DapperRepository.Update.cs
@@ -2,6 +2,7 @@
 using System.Data;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+
 using Dapper;
 
 namespace MicroOrm.Dapper.Repositories
@@ -50,7 +51,7 @@ namespace MicroOrm.Dapper.Repositories
         public virtual bool Update(Expression<Func<TEntity, bool>> predicate, TEntity instance, IDbTransaction transaction)
         {
             var sqlQuery = SqlGenerator.GetUpdate(predicate, instance);
-            var updated = Connection.Execute(sqlQuery.GetSql(), instance, transaction) > 0;
+            var updated = Connection.Execute(sqlQuery.GetSql(), sqlQuery.Param, transaction) > 0;
             return updated;
         }
 
@@ -64,7 +65,7 @@ namespace MicroOrm.Dapper.Repositories
         public virtual async Task<bool> UpdateAsync(Expression<Func<TEntity, bool>> predicate, TEntity instance, IDbTransaction transaction)
         {
             var sqlQuery = SqlGenerator.GetUpdate(predicate, instance);
-            var updated = await Connection.ExecuteAsync(sqlQuery.GetSql(), instance, transaction) > 0;
+            var updated = await Connection.ExecuteAsync(sqlQuery.GetSql(), sqlQuery.Param, transaction) > 0;
             return updated;
         }
     }

--- a/src/MicroOrm.Dapper.Repositories/Extensions/CollectionExtensions.cs
+++ b/src/MicroOrm.Dapper.Repositories/Extensions/CollectionExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+
+namespace MicroOrm.Dapper.Repositories.Extensions
+{
+    internal static class CollectionExtensions
+    {
+        /// <summary>
+        ///     AddRange ICollection
+        /// </summary>
+        /// <param name="collection"></param>
+        /// <param name="addCollection"></param>
+        public static void AddRange<TInput>(this ICollection<TInput> collection, IEnumerable<TInput> addCollection)
+        {
+            if (collection == null || addCollection == null)
+                return;
+
+            foreach (var item in addCollection)
+            {
+                collection.Add(item);
+            }
+        }
+    }
+}

--- a/src/MicroOrm.Dapper.Repositories/SqlGenerator/ExpressionHelper.cs
+++ b/src/MicroOrm.Dapper.Repositories/SqlGenerator/ExpressionHelper.cs
@@ -83,12 +83,12 @@ namespace MicroOrm.Dapper.Repositories.SqlGenerator
             }
         }
 
-        public static string GetMethodCallSqlOperator(string methodName)
+        public static string GetMethodCallSqlOperator(string methodName, bool isNotUnary = false)
         {
             switch (methodName)
             {
                 case "Contains":
-                    return "IN";
+                    return isNotUnary ? "NOT IN" : "IN";
 
                 case "Any":
                 case "All":

--- a/src/MicroOrm.Dapper.Repositories/SqlGenerator/QueryParameter.cs
+++ b/src/MicroOrm.Dapper.Repositories/SqlGenerator/QueryParameter.cs
@@ -1,19 +1,78 @@
-﻿namespace MicroOrm.Dapper.Repositories.SqlGenerator
+﻿using System.Collections.Generic;
+
+namespace MicroOrm.Dapper.Repositories.SqlGenerator
 {
     /// <summary>
-    ///     Class that models the data structure in coverting the expression tree into SQL and Params.
+    /// Query Expression Node Type
     /// </summary>
-    internal class QueryParameter
+    internal enum QueryExpressionType
+    {
+        Parameter = 0,
+        Binary = 1,
+    }
+
+    /// <summary>
+    /// Abstract Query Expression
+    /// </summary>
+    internal abstract class QueryExpression
     {
         /// <summary>
-        ///     Initializes a new instance of the <see cref="QueryParameter" /> class.
+        /// Query Expression Node Type
+        /// </summary>
+        public QueryExpressionType NodeType { get; set; }
+
+        /// <summary>
+        /// Operator OR/AND
+        /// </summary>
+        public string LinkingOperator { get; set; }
+
+        public override string ToString()
+        {
+            return string.Format("[NodeType:{0}, LinkingOperator:{1}]",
+                                    this.NodeType, this.LinkingOperator);
+        }
+    }
+
+    /// <summary>
+    /// `Binary` Query Expression
+    /// </summary>
+    internal class QueryBinaryExpression : QueryExpression
+    {
+        public QueryBinaryExpression()
+        {
+            NodeType = QueryExpressionType.Binary;
+        }
+
+        public List<QueryExpression> Nodes { get; set; }
+
+        public override string ToString()
+        {
+            return string.Format("[{0} ({1})]", base.ToString(), string.Join(",", this.Nodes));
+        }
+    }
+
+    /// <summary>
+    /// Class that models the data structure in coverting the expression tree into SQL and Params.
+    /// `Parameter` Query Expression
+    /// </summary>
+    internal class QueryParameterExpression : QueryExpression
+    {
+        public QueryParameterExpression()
+        {
+            NodeType = QueryExpressionType.Parameter;
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="QueryParameterExpression " /> class.
         /// </summary>
         /// <param name="linkingOperator">The linking operator.</param>
         /// <param name="propertyName">Name of the property.</param>
         /// <param name="propertyValue">The property value.</param>
         /// <param name="queryOperator">The query operator.</param>
         /// <param name="nestedProperty">Signilize if it is nested property.</param>
-        internal QueryParameter(string linkingOperator, string propertyName, object propertyValue, string queryOperator, bool nestedProperty)
+        internal QueryParameterExpression(string linkingOperator,
+            string propertyName, object propertyValue,
+            string queryOperator, bool nestedProperty) : this()
         {
             LinkingOperator = linkingOperator;
             PropertyName = propertyName;
@@ -22,10 +81,17 @@
             NestedProperty = nestedProperty;
         }
 
-        public string LinkingOperator { get; set; }
         public string PropertyName { get; set; }
         public object PropertyValue { get; set; }
         public string QueryOperator { get; set; }
         public bool NestedProperty { get; set; }
+
+        public override string ToString()
+        {
+            return string.Format("[{0}, PropertyName:{1}, PropertyValue:{2}, QueryOperator:{3}, NestedProperty:{4}]",
+                base.ToString(),
+                this.PropertyName, this.PropertyValue,
+                this.QueryOperator, this.NestedProperty);
+        }
     }
 }

--- a/src/MicroOrm.Dapper.Repositories/SqlGenerator/SqlGenerator.cs
+++ b/src/MicroOrm.Dapper.Repositories/SqlGenerator/SqlGenerator.cs
@@ -381,6 +381,17 @@ namespace MicroOrm.Dapper.Repositories.SqlGenerator
                                         string.Join(", ", properties.Select(p => string.Format("{0} = @{1}", p.ColumnName, p.PropertyName)))));
             AppendWherePredicateQuery(query, predicate, QueryType.Update);
 
+            var parameters = new Dictionary<string, object>();
+            var entityType = entity.GetType();
+            foreach (var property in properties)
+                parameters.Add(property.PropertyName, entityType.GetProperty(property.PropertyName).GetValue(entity, null));
+
+            var whereParam = query.Param as Dictionary<string, object>;
+            if (whereParam != null)
+                parameters.AddRange(whereParam);
+
+            query.SetParam(parameters);
+
             return query;
         }
 

--- a/src/MicroOrm.Dapper.Repositories/SqlGenerator/SqlGenerator.cs
+++ b/src/MicroOrm.Dapper.Repositories/SqlGenerator/SqlGenerator.cs
@@ -865,13 +865,20 @@ namespace MicroOrm.Dapper.Repositories.SqlGenerator
                                     break;
 
                                 case QueryBinaryExpression rQBExpr:
-                                    if (rQBExpr.LinkingOperator == rQBExpr.Nodes.Last().LinkingOperator    // AND (c AND d)
-                                        && lQBExpr.Nodes.Last().LinkingOperator == rQBExpr.LinkingOperator) // (a AND b) AND (c AND d)
+                                    if (lQBExpr.Nodes.Last().LinkingOperator == rQBExpr.LinkingOperator) // (a AND b) AND (c AND d)
                                     {
-                                        rQBExpr.Nodes[0].LinkingOperator = rQBExpr.LinkingOperator;
-                                        lQBExpr.Nodes.AddRange(rQBExpr.Nodes);
+                                        if (rQBExpr.LinkingOperator == rQBExpr.Nodes.Last().LinkingOperator)   // AND (c AND d)
+                                        {
+                                            rQBExpr.Nodes[0].LinkingOperator = rQBExpr.LinkingOperator;
+                                            lQBExpr.Nodes.AddRange(rQBExpr.Nodes);
+                                            // (a AND b) AND (c AND d) =>  (a AND b AND c AND d)
+                                        }
+                                        else
+                                        {
+                                            lQBExpr.Nodes.Add(rQBExpr);
+                                            // (a AND b) AND (c OR d) =>  (a AND b AND (c OR d))
+                                        }
                                         rightExpr = null;
-                                        // (a AND b) AND (c AND d) =>  (a AND b AND c AND d)
                                     }
                                     break;
                             }

--- a/test/MicroOrm.Dapper.Repositories.Tests/OtherTests/ExpressionHelperTests.cs
+++ b/test/MicroOrm.Dapper.Repositories.Tests/OtherTests/ExpressionHelperTests.cs
@@ -12,7 +12,14 @@ namespace MicroOrm.Dapper.Repositories.Tests.OtherTests
             var result = ExpressionHelper.GetMethodCallSqlOperator("Contains");
             Assert.Equal("IN", result);
         }
-        
+
+        [Fact]
+        public void GetMethodCallSqlOperator_NotContains()
+        {
+            var result = ExpressionHelper.GetMethodCallSqlOperator("Contains", true);
+            Assert.Equal("NOT IN", result);
+        }
+
         [Fact]
         public void GetMethodCallSqlOperator_Any()
         {

--- a/test/MicroOrm.Dapper.Repositories.Tests/SqlGeneratorTests/MsSqlGeneratorTests.cs
+++ b/test/MicroOrm.Dapper.Repositories.Tests/SqlGeneratorTests/MsSqlGeneratorTests.cs
@@ -34,7 +34,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
         {
             ISqlGenerator<User> userSqlGenerator = new SqlGenerator<User>(_sqlConnector, true);
             var sqlQuery = userSqlGenerator.GetCount(x => x.PhoneId == 1, user => user.AddressId);
-            Assert.Equal("SELECT COUNT(DISTINCT [Users].[AddressId]) FROM [Users] WHERE [Users].[PhoneId] = @PhoneId AND [Users].[Deleted] != 1", sqlQuery.GetSql());
+            Assert.Equal("SELECT COUNT(DISTINCT [Users].[AddressId]) FROM [Users] WHERE ([Users].[PhoneId] = @PhoneId_p0) AND [Users].[Deleted] != 1", sqlQuery.GetSql());
         }
 
         [Fact]
@@ -85,9 +85,9 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             var sqlQuery = userSqlGenerator.GetSelectFirst(x => x.IsActive != true);
 
             var parameters = sqlQuery.Param as IDictionary<string, object>;
-            Assert.True(Convert.ToBoolean(parameters["IsActive"]));
+            Assert.True(Convert.ToBoolean(parameters["IsActive_p0"]));
 
-            Assert.Equal("SELECT TOP 1 [DAB].[Phones].[Id], [DAB].[Phones].[Number], [DAB].[Phones].[IsActive], [DAB].[Phones].[Code] FROM [DAB].[Phones] WHERE [DAB].[Phones].[IsActive] != @IsActive", sqlQuery.GetSql());
+            Assert.Equal("SELECT TOP 1 [DAB].[Phones].[Id], [DAB].[Phones].[Number], [DAB].[Phones].[IsActive], [DAB].[Phones].[Code] FROM [DAB].[Phones] WHERE [DAB].[Phones].[IsActive] != @IsActive_p0", sqlQuery.GetSql());
         }
 
         [Fact]
@@ -97,9 +97,9 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             var sqlQuery = userSqlGenerator.GetSelectFirst(x => x.IsActive == false);
 
             var parameters = sqlQuery.Param as IDictionary<string, object>;
-            Assert.False(Convert.ToBoolean(parameters["IsActive"]));
+            Assert.False(Convert.ToBoolean(parameters["IsActive_p0"]));
 
-            Assert.Equal("SELECT TOP 1 [DAB].[Phones].[Id], [DAB].[Phones].[Number], [DAB].[Phones].[IsActive], [DAB].[Phones].[Code] FROM [DAB].[Phones] WHERE [DAB].[Phones].[IsActive] = @IsActive", sqlQuery.GetSql());
+            Assert.Equal("SELECT TOP 1 [DAB].[Phones].[Id], [DAB].[Phones].[Number], [DAB].[Phones].[IsActive], [DAB].[Phones].[Code] FROM [DAB].[Phones] WHERE [DAB].[Phones].[IsActive] = @IsActive_p0", sqlQuery.GetSql());
         }
 
         [Fact]
@@ -109,9 +109,9 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             var sqlQuery = userSqlGenerator.GetSelectFirst(x => !x.IsActive);
 
             var parameters = sqlQuery.Param as IDictionary<string, object>;
-            Assert.False(Convert.ToBoolean(parameters["IsActive"]));
+            Assert.False(Convert.ToBoolean(parameters["IsActive_p0"]));
 
-            Assert.Equal("SELECT TOP 1 [DAB].[Phones].[Id], [DAB].[Phones].[Number], [DAB].[Phones].[IsActive], [DAB].[Phones].[Code] FROM [DAB].[Phones] WHERE [DAB].[Phones].[IsActive] = @IsActive", sqlQuery.GetSql());
+            Assert.Equal("SELECT TOP 1 [DAB].[Phones].[Id], [DAB].[Phones].[Number], [DAB].[Phones].[IsActive], [DAB].[Phones].[Code] FROM [DAB].[Phones] WHERE [DAB].[Phones].[IsActive] = @IsActive_p0", sqlQuery.GetSql());
         }
 
         [Fact]
@@ -121,9 +121,9 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             var sqlQuery = userSqlGenerator.GetSelectFirst(x => x.IsActive);
 
             var parameters = sqlQuery.Param as IDictionary<string, object>;
-            Assert.True(Convert.ToBoolean(parameters["IsActive"]));
+            Assert.True(Convert.ToBoolean(parameters["IsActive_p0"]));
 
-            Assert.Equal("SELECT TOP 1 [DAB].[Phones].[Id], [DAB].[Phones].[Number], [DAB].[Phones].[IsActive], [DAB].[Phones].[Code] FROM [DAB].[Phones] WHERE [DAB].[Phones].[IsActive] = @IsActive", sqlQuery.GetSql());
+            Assert.Equal("SELECT TOP 1 [DAB].[Phones].[Id], [DAB].[Phones].[Number], [DAB].[Phones].[IsActive], [DAB].[Phones].[Code] FROM [DAB].[Phones] WHERE [DAB].[Phones].[IsActive] = @IsActive_p0", sqlQuery.GetSql());
         }
 
         [Fact]
@@ -184,7 +184,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             var sqlQuery = userSqlGenerator.GetSelectAll(x => ids.Contains(x.Id));
 
             Assert.Equal("SELECT [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[OfficePhoneId], [Users].[Deleted], [Users].[UpdatedAt] " +
-                         "FROM [Users] WHERE [Users].[Id] IN @Id AND [Users].[Deleted] != 1", sqlQuery.GetSql());
+                         "FROM [Users] WHERE ([Users].[Id] IN @Id_p0) AND [Users].[Deleted] != 1", sqlQuery.GetSql());
         }
 
         [Fact]
@@ -195,7 +195,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             var sqlQuery = userSqlGenerator.GetSelectAll(x => !ids.Contains(x.Id));
 
             Assert.Equal("SELECT [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[OfficePhoneId], [Users].[Deleted], [Users].[UpdatedAt] " +
-                         "FROM [Users] WHERE [Users].[Id] NOT IN @Id AND [Users].[Deleted] != 1", sqlQuery.GetSql());
+                         "FROM [Users] WHERE ([Users].[Id] NOT IN @Id_p0) AND [Users].[Deleted] != 1", sqlQuery.GetSql());
         }
 
         [Fact]
@@ -249,7 +249,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             var sqlQuery = sqlGenerator.GetDelete(q => q.Id == 10);
             var realSql = sqlQuery.GetSql();
 
-            Assert.Equal("UPDATE Cars SET Status = -1 WHERE Cars.Id = @Id", realSql);
+            Assert.Equal("UPDATE Cars SET Status = -1 WHERE Cars.Id = @Id_p0", realSql);
         }
 
         [Fact]
@@ -258,7 +258,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             ISqlGenerator<Phone> userSqlGenerator = new SqlGenerator<Phone>(_sqlConnector, true);
             var sqlQuery = userSqlGenerator.GetDelete(x => x.IsActive && x.Number == "111");
 
-            Assert.Equal("DELETE FROM [DAB].[Phones] WHERE [DAB].[Phones].[IsActive] = @IsActive AND [DAB].[Phones].[Number] = @Number", sqlQuery.GetSql());
+            Assert.Equal("DELETE FROM [DAB].[Phones] WHERE [DAB].[Phones].[IsActive] = @IsActive_p0 AND [DAB].[Phones].[Number] = @Number_p1", sqlQuery.GetSql());
         }
 
         [Fact]
@@ -267,7 +267,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             ISqlGenerator<Phone> userSqlGenerator = new SqlGenerator<Phone>(_sqlConnector, true);
             var sqlQuery = userSqlGenerator.GetDelete(x => x.IsActive);
 
-            Assert.Equal("DELETE FROM [DAB].[Phones] WHERE [DAB].[Phones].[IsActive] = @IsActive", sqlQuery.GetSql());
+            Assert.Equal("DELETE FROM [DAB].[Phones] WHERE [DAB].[Phones].[IsActive] = @IsActive_p0", sqlQuery.GetSql());
         }
 
         [Fact]
@@ -286,7 +286,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             var sqlQuery = userSqlGenerator.GetSelectAll(user => user.UpdatedAt == null);
 
             Assert.Equal("SELECT [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[OfficePhoneId], [Users].[Deleted], [Users].[UpdatedAt] FROM [Users] " +
-                         "WHERE [Users].[UpdatedAt] IS NULL AND [Users].[Deleted] != 1", sqlQuery.GetSql());
+                         "WHERE ([Users].[UpdatedAt] IS NULL) AND [Users].[Deleted] != 1", sqlQuery.GetSql());
             Assert.DoesNotContain("== NULL", sqlQuery.GetSql());
         }
 
@@ -311,7 +311,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             Assert.Equal("SELECT TOP 1 [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[OfficePhoneId], [Users].[Deleted], [Users].[UpdatedAt], " +
                          "[Phones_PhoneId].[Id], [Phones_PhoneId].[Number], [Phones_PhoneId].[IsActive], [Phones_PhoneId].[Code] " +
                          "FROM [Users] INNER JOIN [DAB].[Phones] AS [Phones_PhoneId] ON [Users].[PhoneId] = [Phones_PhoneId].[Id] " +
-                         "WHERE [Phones_PhoneId].[Number] = @PhoneNumber AND [Users].[Deleted] != 1", sqlQuery.GetSql());
+                         "WHERE ([Phones_PhoneId].[Number] = @PhoneNumber_p0) AND [Users].[Deleted] != 1", sqlQuery.GetSql());
         }
 
         [Fact]
@@ -323,7 +323,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             Assert.Equal("SELECT TOP 1 Users.Id, Users.Name, Users.AddressId, Users.PhoneId, Users.OfficePhoneId, Users.Deleted, Users.UpdatedAt, " +
                          "Phones_PhoneId.Id, Phones_PhoneId.Number, Phones_PhoneId.IsActive, Phones_PhoneId.Code " +
                          "FROM Users INNER JOIN DAB.Phones AS Phones_PhoneId ON Users.PhoneId = Phones_PhoneId.Id " +
-                         "WHERE Phones_PhoneId.Number = @PhoneNumber AND Users.Deleted != 1", sqlQuery.GetSql());
+                         "WHERE (Phones_PhoneId.Number = @PhoneNumber_p0) AND Users.Deleted != 1", sqlQuery.GetSql());
         }
 
         [Fact]
@@ -381,7 +381,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
         {
             ISqlGenerator<User> userSqlGenerator = new SqlGenerator<User>(_sqlConnector, true);
             var sqlQuery = userSqlGenerator.GetSelectFirst(x => x.Id == 2);
-            Assert.Equal("SELECT TOP 1 [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[OfficePhoneId], [Users].[Deleted], [Users].[UpdatedAt] FROM [Users] WHERE [Users].[Id] = @Id AND [Users].[Deleted] != 1", sqlQuery.GetSql());
+            Assert.Equal("SELECT TOP 1 [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[OfficePhoneId], [Users].[Deleted], [Users].[UpdatedAt] FROM [Users] WHERE ([Users].[Id] = @Id_p0) AND [Users].[Deleted] != 1", sqlQuery.GetSql());
         }
 
         [Fact]
@@ -400,7 +400,40 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             ISqlGenerator<City> sqlGenerator = new SqlGenerator<City>(_sqlConnector);
             var sqlQuery = sqlGenerator.GetUpdate(q => q.Identifier == Guid.Empty, new City());
             var sql = sqlQuery.GetSql();
-            Assert.Equal("UPDATE Cities SET Identifier = @Identifier, Name = @Name WHERE Cities.Identifier = @Identifier", sql);
+            Assert.Equal("UPDATE Cities SET Identifier = @Identifier, Name = @Name WHERE Cities.Identifier = @Identifier_p0", sql);
         }
+
+        #region Support `group conditions` syntax
+        [Fact]
+        public static void SelectGroupConditionsWithPredicate()
+        {
+            ISqlGenerator<Phone> userSqlGenerator = new SqlGenerator<Phone>(_sqlConnector, true);
+            var sPrefix = "SELECT [DAB].[Phones].[Id], [DAB].[Phones].[Number], [DAB].[Phones].[IsActive], [DAB].[Phones].[Code] FROM [DAB].[Phones] WHERE ";
+            var sqlQuery1 = userSqlGenerator.GetSelectAll(x => (x.IsActive && x.Id == 123) || (x.Id == 456 && x.Number == "456"));
+            Assert.Equal(sPrefix + "([DAB].[Phones].[IsActive] = @IsActive_p0 AND [DAB].[Phones].[Id] = @Id_p1) OR ([DAB].[Phones].[Id] = @Id_p2 AND [DAB].[Phones].[Number] = @Number_p3)", sqlQuery1.GetSql());
+
+            var sqlQuery2 = userSqlGenerator.GetSelectAll(x => !x.IsActive || (x.Id == 456 && x.Number == "456"));
+            Assert.Equal(sPrefix + "[DAB].[Phones].[IsActive] = @IsActive_p0 OR ([DAB].[Phones].[Id] = @Id_p1 AND [DAB].[Phones].[Number] = @Number_p2)", sqlQuery2.GetSql());
+
+            var sqlQuery3 = userSqlGenerator.GetSelectAll(x => (x.Id == 456 && x.Number == "456") || x.Id == 123);
+            Assert.Equal(sPrefix + "([DAB].[Phones].[Id] = @Id_p0 AND [DAB].[Phones].[Number] = @Number_p1) OR [DAB].[Phones].[Id] = @Id_p2", sqlQuery3.GetSql());
+
+            var sqlQuery4 = userSqlGenerator.GetSelectAll(x => x.Number == "1" && (x.IsActive || x.Number == "456") && x.Id == 123);
+            Assert.Equal(sPrefix + "[DAB].[Phones].[Number] = @Number_p0 AND ([DAB].[Phones].[IsActive] = @IsActive_p1 OR [DAB].[Phones].[Number] = @Number_p2) AND [DAB].[Phones].[Id] = @Id_p3", sqlQuery4.GetSql());
+
+            var sqlQuery5 = userSqlGenerator.GetSelectAll(x => x.Number == "1" && (x.IsActive || x.Number == "456" || x.Number == "678") && x.Id == 123);
+            Assert.Equal(sPrefix + "[DAB].[Phones].[Number] = @Number_p0 AND ([DAB].[Phones].[IsActive] = @IsActive_p1 OR [DAB].[Phones].[Number] = @Number_p2 OR [DAB].[Phones].[Number] = @Number_p3) AND [DAB].[Phones].[Id] = @Id_p4", sqlQuery5.GetSql());
+
+            var ids = new List<int>();
+            var sqlQuery6 = userSqlGenerator.GetSelectAll(x => !x.IsActive || (x.IsActive && ids.Contains(x.Id)));
+            Assert.Equal(sPrefix + "[DAB].[Phones].[IsActive] = @IsActive_p0 OR ([DAB].[Phones].[IsActive] = @IsActive_p1 AND [DAB].[Phones].[Id] IN @Id_p2)", sqlQuery6.GetSql());
+
+            var sqlQuery7 = userSqlGenerator.GetSelectAll(x => (x.IsActive && x.Id == 123) && (x.Id == 456 && x.Number == "456"));
+            Assert.Equal(sPrefix + "[DAB].[Phones].[IsActive] = @IsActive_p0 AND [DAB].[Phones].[Id] = @Id_p1 AND [DAB].[Phones].[Id] = @Id_p2 AND [DAB].[Phones].[Number] = @Number_p3", sqlQuery7.GetSql());
+
+            var sqlQuery8 = userSqlGenerator.GetSelectAll(x => x.Number == "1" && (x.IsActive || x.Number == "456" || x.Number == "123" || (x.Id == 1213 && x.Number == "678")) && x.Id == 123);
+            Assert.Equal(sPrefix + "[DAB].[Phones].[Number] = @Number_p0 AND (([DAB].[Phones].[IsActive] = @IsActive_p1 OR [DAB].[Phones].[Number] = @Number_p2 OR [DAB].[Phones].[Number] = @Number_p3) OR ([DAB].[Phones].[Id] = @Id_p4 AND [DAB].[Phones].[Number] = @Number_p5)) AND [DAB].[Phones].[Id] = @Id_p6", sqlQuery8.GetSql());
+        }
+        #endregion
     }
 }

--- a/test/MicroOrm.Dapper.Repositories.Tests/SqlGeneratorTests/MsSqlGeneratorTests.cs
+++ b/test/MicroOrm.Dapper.Repositories.Tests/SqlGeneratorTests/MsSqlGeneratorTests.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using MicroOrm.Dapper.Repositories.SqlGenerator;
 using MicroOrm.Dapper.Repositories.Tests.Classes;
+
 using Xunit;
 
 namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
@@ -186,6 +188,17 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
         }
 
         [Fact]
+        public static void NotContainsPredicate()
+        {
+            ISqlGenerator<User> userSqlGenerator = new SqlGenerator<User>(_sqlConnector, true);
+            var ids = new List<int>();
+            var sqlQuery = userSqlGenerator.GetSelectAll(x => !ids.Contains(x.Id));
+
+            Assert.Equal("SELECT [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[OfficePhoneId], [Users].[Deleted], [Users].[UpdatedAt] " +
+                         "FROM [Users] WHERE [Users].[Id] NOT IN @Id AND [Users].[Deleted] != 1", sqlQuery.GetSql());
+        }
+
+        [Fact]
         public static void LogicalDeleteWithUpdatedAt()
         {
             ISqlGenerator<User> userSqlGenerator = new SqlGenerator<User>(_sqlConnector);
@@ -238,7 +251,6 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
 
             Assert.Equal("UPDATE Cars SET Status = -1 WHERE Cars.Id = @Id", realSql);
         }
-
 
         [Fact]
         public static void DeleteWithMultiplePredicate()
@@ -314,7 +326,6 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
                          "WHERE Phones_PhoneId.Number = @PhoneNumber AND Users.Deleted != 1", sqlQuery.GetSql());
         }
 
-
         [Fact]
         public static void SelectBetweenWithLogicalDelete()
         {
@@ -334,7 +345,6 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             Assert.Equal("SELECT [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[OfficePhoneId], [Users].[Deleted], [Users].[UpdatedAt] FROM [Users] " +
                          "WHERE [Users].[Deleted] != 1 AND [Users].[Id] BETWEEN '1' AND '10'", sqlQuery.GetSql());
         }
-
 
         [Fact]
         public static void SelectBetweenWithoutLogicalDelete()
@@ -383,7 +393,6 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
 
             Assert.Equal("UPDATE [DAB].[Phones] SET [Number] = @Number, [IsActive] = @IsActive WHERE [Id] = @Id", sqlQuery.GetSql());
         }
-
 
         [Fact]
         public static void UpdateWithPredicate()

--- a/test/MicroOrm.Dapper.Repositories.Tests/SqlGeneratorTests/MySqlGeneratorTests.cs
+++ b/test/MicroOrm.Dapper.Repositories.Tests/SqlGeneratorTests/MySqlGeneratorTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using MicroOrm.Dapper.Repositories.SqlGenerator;
 using MicroOrm.Dapper.Repositories.Tests.Classes;
+
 using Xunit;
 
 namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
@@ -31,7 +33,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
         {
             ISqlGenerator<User> userSqlGenerator = new SqlGenerator<User>(_sqlConnector, true);
             var sqlQuery = userSqlGenerator.GetCount(x => x.PhoneId == 1, user => user.AddressId);
-            Assert.Equal("SELECT COUNT(DISTINCT `Users`.`AddressId`) FROM `Users` WHERE `Users`.`PhoneId` = @PhoneId AND `Users`.`Deleted` != 1", sqlQuery.GetSql());
+            Assert.Equal("SELECT COUNT(DISTINCT `Users`.`AddressId`) FROM `Users` WHERE (`Users`.`PhoneId` = @PhoneId_p0) AND `Users`.`Deleted` != 1", sqlQuery.GetSql());
         }
 
         [Fact]
@@ -49,7 +51,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             Assert.Equal("UPDATE DAB.Phones SET Number = @Number0, IsActive = @IsActive0 WHERE Id = @Id0; " +
                          "UPDATE DAB.Phones SET Number = @Number1, IsActive = @IsActive1 WHERE Id = @Id1", sqlQuery.GetSql());
         }
-        
+
         [Fact]
         public void BulkUpdate_QuoMarks()
         {
@@ -82,10 +84,9 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             var sqlQuery = userSqlGenerator.GetSelectAll(user => user.UpdatedAt != null);
 
             Assert.Equal("SELECT `Users`.`Id`, `Users`.`Name`, `Users`.`AddressId`, `Users`.`PhoneId`, `Users`.`OfficePhoneId`, `Users`.`Deleted`, `Users`.`UpdatedAt` FROM `Users` " +
-                         "WHERE `Users`.`UpdatedAt` IS NOT NULL AND `Users`.`Deleted` != 1", sqlQuery.GetSql());
+                         "WHERE (`Users`.`UpdatedAt` IS NOT NULL) AND `Users`.`Deleted` != 1", sqlQuery.GetSql());
             Assert.DoesNotContain("!= NULL", sqlQuery.GetSql());
         }
-
 
         [Fact]
         public void IsNotNullAnd()
@@ -94,15 +95,14 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             var sqlQuery = userSqlGenerator.GetSelectAll(user => user.Name == "Frank" && user.UpdatedAt != null);
 
             Assert.Equal("SELECT `Users`.`Id`, `Users`.`Name`, `Users`.`AddressId`, `Users`.`PhoneId`, `Users`.`OfficePhoneId`, `Users`.`Deleted`, `Users`.`UpdatedAt` FROM `Users` " +
-                         "WHERE `Users`.`Name` = @Name AND `Users`.`UpdatedAt` IS NOT NULL AND `Users`.`Deleted` != 1", sqlQuery.GetSql());
+                         "WHERE (`Users`.`Name` = @Name_p0 AND `Users`.`UpdatedAt` IS NOT NULL) AND `Users`.`Deleted` != 1", sqlQuery.GetSql());
             Assert.DoesNotContain("!= NULL", sqlQuery.GetSql());
 
             sqlQuery = userSqlGenerator.GetSelectAll(user => user.UpdatedAt != null && user.Name == "Frank");
             Assert.Equal("SELECT `Users`.`Id`, `Users`.`Name`, `Users`.`AddressId`, `Users`.`PhoneId`, `Users`.`OfficePhoneId`, `Users`.`Deleted`, `Users`.`UpdatedAt` FROM `Users` " +
-                         "WHERE `Users`.`UpdatedAt` IS NOT NULL AND `Users`.`Name` = @Name AND `Users`.`Deleted` != 1", sqlQuery.GetSql());
+                         "WHERE (`Users`.`UpdatedAt` IS NOT NULL AND `Users`.`Name` = @Name_p1) AND `Users`.`Deleted` != 1", sqlQuery.GetSql());
             Assert.DoesNotContain("!= NULL", sqlQuery.GetSql());
         }
-
 
         [Fact]
         public void SelectBetween()
@@ -127,7 +127,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
         {
             ISqlGenerator<City> sqlGenerator = new SqlGenerator<City>(_sqlConnector, false);
             var sqlQuery = sqlGenerator.GetSelectFirst(x => x.Identifier == Guid.Empty);
-            Assert.Equal("SELECT Cities.Identifier, Cities.Name FROM Cities WHERE Cities.Identifier = @Identifier LIMIT 1", sqlQuery.GetSql());
+            Assert.Equal("SELECT Cities.Identifier, Cities.Name FROM Cities WHERE Cities.Identifier = @Identifier_p0 LIMIT 1", sqlQuery.GetSql());
         }
 
         [Fact]
@@ -135,7 +135,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
         {
             ISqlGenerator<City> sqlGenerator = new SqlGenerator<City>(_sqlConnector, false);
             var sqlQuery = sqlGenerator.GetSelectFirst(x => x.Identifier == Guid.Empty && x.Name == "");
-            Assert.Equal("SELECT Cities.Identifier, Cities.Name FROM Cities WHERE Cities.Identifier = @Identifier AND Cities.Name = @Name LIMIT 1", sqlQuery.GetSql());
+            Assert.Equal("SELECT Cities.Identifier, Cities.Name FROM Cities WHERE Cities.Identifier = @Identifier_p0 AND Cities.Name = @Name_p1 LIMIT 1", sqlQuery.GetSql());
         }
 
         [Fact]
@@ -143,16 +143,15 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
         {
             ISqlGenerator<City> sqlGenerator = new SqlGenerator<City>(_sqlConnector, true);
             var sqlQuery = sqlGenerator.GetSelectFirst(x => x.Identifier == Guid.Empty);
-            Assert.Equal("SELECT `Cities`.`Identifier`, `Cities`.`Name` FROM `Cities` WHERE `Cities`.`Identifier` = @Identifier LIMIT 1", sqlQuery.GetSql());
+            Assert.Equal("SELECT `Cities`.`Identifier`, `Cities`.`Name` FROM `Cities` WHERE `Cities`.`Identifier` = @Identifier_p0 LIMIT 1", sqlQuery.GetSql());
         }
-
 
         [Fact]
         public void SelectFirstWithDeleted()
         {
             ISqlGenerator<User> userSqlGenerator = new SqlGenerator<User>(_sqlConnector, true);
             var sqlQuery = userSqlGenerator.GetSelectFirst(x => x.Id == 6);
-            Assert.Equal("SELECT `Users`.`Id`, `Users`.`Name`, `Users`.`AddressId`, `Users`.`PhoneId`, `Users`.`OfficePhoneId`, `Users`.`Deleted`, `Users`.`UpdatedAt` FROM `Users` WHERE `Users`.`Id` = @Id AND `Users`.`Deleted` != 1 LIMIT 1", sqlQuery.GetSql());
+            Assert.Equal("SELECT `Users`.`Id`, `Users`.`Name`, `Users`.`AddressId`, `Users`.`PhoneId`, `Users`.`OfficePhoneId`, `Users`.`Deleted`, `Users`.`UpdatedAt` FROM `Users` WHERE (`Users`.`Id` = @Id_p0) AND `Users`.`Deleted` != 1 LIMIT 1", sqlQuery.GetSql());
         }
     }
 }

--- a/test/MicroOrm.Dapper.Repositories.Tests/SqlGeneratorTests/PostgresSqlGeneratorTests.cs
+++ b/test/MicroOrm.Dapper.Repositories.Tests/SqlGeneratorTests/PostgresSqlGeneratorTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using MicroOrm.Dapper.Repositories.SqlGenerator;
 using MicroOrm.Dapper.Repositories.Tests.Classes;
+
 using Xunit;
 
 namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
@@ -31,7 +33,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
         {
             ISqlGenerator<User> userSqlGenerator = new SqlGenerator<User>(_sqlConnector, true);
             var sqlQuery = userSqlGenerator.GetCount(x => x.PhoneId == 1, user => user.AddressId);
-            Assert.Equal("SELECT COUNT(DISTINCT \"Users\".\"AddressId\") FROM \"Users\" WHERE \"Users\".\"PhoneId\" = @PhoneId AND \"Users\".\"Deleted\" != 1", sqlQuery.GetSql());
+            Assert.Equal("SELECT COUNT(DISTINCT \"Users\".\"AddressId\") FROM \"Users\" WHERE (\"Users\".\"PhoneId\" = @PhoneId_p0) AND \"Users\".\"Deleted\" != 1", sqlQuery.GetSql());
         }
 
         [Fact]
@@ -39,18 +41,17 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
         {
             ISqlGenerator<City> sqlGenerator = new SqlGenerator<City>(_sqlConnector);
             var sqlQuery = sqlGenerator.GetSelectFirst(x => x.Identifier == Guid.Empty);
-            Assert.Equal("SELECT Cities.Identifier, Cities.Name FROM Cities WHERE Cities.Identifier = @Identifier LIMIT 1", sqlQuery.GetSql());
+            Assert.Equal("SELECT Cities.Identifier, Cities.Name FROM Cities WHERE Cities.Identifier = @Identifier_p0 LIMIT 1", sqlQuery.GetSql());
         }
-
 
         [Fact]
         public void SelectFirst_QuoMarks()
         {
             ISqlGenerator<City> sqlGenerator = new SqlGenerator<City>(_sqlConnector, true);
             var sqlQuery = sqlGenerator.GetSelectFirst(x => x.Identifier == Guid.Empty);
-            Assert.Equal("SELECT \"Cities\".\"Identifier\", \"Cities\".\"Name\" FROM \"Cities\" WHERE \"Cities\".\"Identifier\" = @Identifier LIMIT 1", sqlQuery.GetSql());
+            Assert.Equal("SELECT \"Cities\".\"Identifier\", \"Cities\".\"Name\" FROM \"Cities\" WHERE \"Cities\".\"Identifier\" = @Identifier_p0 LIMIT 1", sqlQuery.GetSql());
         }
-               
+
         [Fact]
         public static void BulkUpdate()
         {
@@ -66,7 +67,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             Assert.Equal("UPDATE DAB.Phones SET Number = @Number0, IsActive = @IsActive0 WHERE Id = @Id0; " +
                          "UPDATE DAB.Phones SET Number = @Number1, IsActive = @IsActive1 WHERE Id = @Id1", sqlQuery.GetSql());
         }
-        
+
         [Fact]
         public static void BulkUpdate_QuoMarks()
         {


### PR DESCRIPTION
1. Support `NOT IN @a`  syntax.
    - Example: `sql.GetSelectAll(x => !ids.Contains(x.Id))` 
    - Output: `WHERE Id NOT IN @Id_p0`

2. Support `group conditions` syntax
    - Example: `sql.GetSelectAll(x => (x.IsActive && x.Id == 123) || (x.Id == 456 && x.Number == "456"))`
    - Output: `WHERE (IsActive = @IsActive_p0 AND Id = @Id_p1) OR (Id = @Id_p2 AND Number = @Number_p3)`
