### PR TITLE
Support `LIKE` syntax & Support Array `Contains` syntax

### DIFF
--- a/test/MicroOrm.Dapper.Repositories.Tests/OtherTests/ExpressionHelperTests.cs
+++ b/test/MicroOrm.Dapper.Repositories.Tests/OtherTests/ExpressionHelperTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+
 using MicroOrm.Dapper.Repositories.SqlGenerator;
+
 using Xunit;
 
 namespace MicroOrm.Dapper.Repositories.Tests.OtherTests
@@ -26,18 +28,44 @@ namespace MicroOrm.Dapper.Repositories.Tests.OtherTests
             var result = ExpressionHelper.GetMethodCallSqlOperator("Any");
             Assert.Equal("ANY", result);
         }
-        
+
         [Fact]
         public void GetMethodCallSqlOperator_All()
         {
             var result = ExpressionHelper.GetMethodCallSqlOperator("All");
             Assert.Equal("ALL", result);
         }
-        
+
         [Fact]
         public void GetMethodCallSqlOperator_all()
         {
             Assert.Throws<NotSupportedException>(() => ExpressionHelper.GetMethodCallSqlOperator("all"));
+        }
+
+        [Fact]
+        public void GetMethodCallSqlOperator_Like()
+        {
+            var result1 = ExpressionHelper.GetMethodCallSqlOperator("StartsWith");
+            Assert.Equal("LIKE", result1);
+
+            var result2 = ExpressionHelper.GetMethodCallSqlOperator("StringContains", true);
+            Assert.Equal("NOT LIKE", result2);
+
+            var result3 = ExpressionHelper.GetMethodCallSqlOperator("EndsWith");
+            Assert.Equal("LIKE", result3);
+        }
+
+        [Fact]
+        public void GetSqlLikeValue_Like()
+        {
+            var result1 = ExpressionHelper.GetSqlLikeValue("StartsWith", "123");
+            Assert.Equal("123%", result1);
+
+            var result2 = ExpressionHelper.GetSqlLikeValue("StringContains", "456");
+            Assert.Equal("%456%", result2);
+
+            var result3 = ExpressionHelper.GetSqlLikeValue("EndsWith", 789);
+            Assert.Equal("%789", result3);
         }
     }
 }

--- a/test/MicroOrm.Dapper.Repositories.Tests/RepositoriesTests/RepositoriesTests.cs
+++ b/test/MicroOrm.Dapper.Repositories.Tests/RepositoriesTests/RepositoriesTests.cs
@@ -2,9 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+
 using Dapper;
+
 using MicroOrm.Dapper.Repositories.Tests.Classes;
 using MicroOrm.Dapper.Repositories.Tests.DbContexts;
+
 using Xunit;
 
 namespace MicroOrm.Dapper.Repositories.Tests.RepositoriesTests
@@ -17,7 +20,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.RepositoriesTests
         {
             _db = db;
         }
-        
+
         [Fact]
         public async Task ChangeDateInsertAndFind()
         {
@@ -26,7 +29,6 @@ namespace MicroOrm.Dapper.Repositories.Tests.RepositoriesTests
             var user = new User { Name = "Sergey Phoenix", UpdatedAt = dateTime };
             await _db.Users.InsertAsync(user);
             var userFromDb = await _db.Users.FindAsync(q => q.Id == user.Id);
-
 
             Assert.Equal(1, userFromDb.UpdatedAt.Value.CompareTo(dateTime));
         }
@@ -45,10 +47,9 @@ namespace MicroOrm.Dapper.Repositories.Tests.RepositoriesTests
         public void CountWithCondition()
         {
             var count = _db.Users.Count(x => x.Id == 2);
-   
+
             Assert.Equal(1, count);
         }
-
 
         [Fact]
         public void CountWithDistinct()
@@ -61,7 +62,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.RepositoriesTests
         [Fact]
         public void CountWithDistinctAndWhere()
         {
-            var count = _db.Users.Count(x=>x.PhoneId == 1, user => user.PhoneId);
+            var count = _db.Users.Count(x => x.PhoneId == 1, user => user.PhoneId);
 
             Assert.Equal(1, count);
         }
@@ -166,7 +167,6 @@ namespace MicroOrm.Dapper.Repositories.Tests.RepositoriesTests
             var phone4 = await _db.Phones.FindAsync(x => x.Number == "333" && !x.IsActive);
             Assert.NotNull(phone4);
         }
-
 
         [Fact]
         public void FindAllJoin2Table()
@@ -274,16 +274,16 @@ namespace MicroOrm.Dapper.Repositories.Tests.RepositoriesTests
                 Name = "Sergey"
             };
 
-            var insert =  _db.Users.Insert(user);
+            var insert = _db.Users.Insert(user);
             Assert.True(insert);
 
-            var userFromDb =  _db.Users.Find(q => q.Id == user.Id);
+            var userFromDb = _db.Users.Find(q => q.Id == user.Id);
             Assert.Equal(user.Name, userFromDb.Name);
             user.Name = "Sergey1";
 
-            var update =  _db.Users.Update(user);
+            var update = _db.Users.Update(user);
             Assert.True(update);
-            userFromDb =  _db.Users.Find(q => q.Id == user.Id);
+            userFromDb = _db.Users.Find(q => q.Id == user.Id);
             Assert.Equal("Sergey1", userFromDb.Name);
         }
 
@@ -307,7 +307,6 @@ namespace MicroOrm.Dapper.Repositories.Tests.RepositoriesTests
             userFromDb = await _db.Users.FindAsync(q => q.Id == user.Id);
             Assert.Equal("Sergey1", userFromDb.Name);
         }
-
 
         [Fact]
         public void InsertBinaryData()
@@ -566,7 +565,6 @@ namespace MicroOrm.Dapper.Repositories.Tests.RepositoriesTests
             Assert.Equal("MSK777", newPhone2.Number);
         }
 
-
         [Fact]
         public async Task LogicalDeleteWithUpdatedAt()
         {
@@ -585,9 +583,7 @@ namespace MicroOrm.Dapper.Repositories.Tests.RepositoriesTests
             user = await _db.Users.FindAsync(q => q.Name == name);
 
             Assert.Null(user);
-
         }
-
 
         [Fact]
         public async Task LogicalDeleteWithUpdatedAtWithPredicate()
@@ -595,7 +591,6 @@ namespace MicroOrm.Dapper.Repositories.Tests.RepositoriesTests
             const string name = "testLogicalDeleted2";
             var user = new User()
             {
-
                 Name = name
             };
 
@@ -608,7 +603,6 @@ namespace MicroOrm.Dapper.Repositories.Tests.RepositoriesTests
             user = await _db.Users.FindAsync(q => q.Name == name);
 
             Assert.Null(user);
-
         }
 
         [Fact]
@@ -645,6 +639,37 @@ namespace MicroOrm.Dapper.Repositories.Tests.RepositoriesTests
             city = await _db.Cities.FindAsync(q => q.Identifier == identifier);
             Assert.NotNull(city);
             Assert.Equal("Moscow1", city.Name);
+        }
+
+        [Fact]
+        public async Task FindAllByContainsArrayMultipleList()
+        {
+            var keyList = new int[] { 2, 3, 4 };
+            var users = (await _db.Users.FindAllAsync(x => keyList.Contains(x.Id))).ToArray();
+            var usersArray = users.ToArray();
+            Assert.Equal(3, usersArray.Length);
+            Assert.Equal("TestName1", usersArray[0].Name);
+            Assert.Equal("TestName2", usersArray[1].Name);
+            Assert.Equal("TestName3", usersArray[2].Name);
+        }
+
+        [Fact]
+        public async Task FindAllByLikeName()
+        {
+            var users1 = (await _db.Users.FindAllAsync(x => x.Name.EndsWith("Name1"))).ToArray();
+            Assert.Equal("TestName1", users1.First().Name);
+
+            var users2 = (await _db.Users.FindAllAsync(x => x.Name.Contains("Name"))).ToArray();
+            Assert.True(users2.Length > 0);
+
+            var users3 = (await _db.Users.FindAllAsync(x => x.Name.StartsWith("Test"))).ToArray();
+            Assert.True(users3.Length > 0);
+
+            var users4 = (await _db.Users.FindAllAsync(x => !x.Name.StartsWith("est"))).ToArray();
+            Assert.True(users4.Length > 0);
+
+            var users5 = (await _db.Users.FindAllAsync(x => x.Name.StartsWith("est"))).ToArray();
+            Assert.True(users5.Length <= 0);
         }
     }
 }

--- a/test/MicroOrm.Dapper.Repositories.Tests/SqlGeneratorTests/MsSqlGeneratorTests.cs
+++ b/test/MicroOrm.Dapper.Repositories.Tests/SqlGeneratorTests/MsSqlGeneratorTests.cs
@@ -188,6 +188,17 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
         }
 
         [Fact]
+        public static void ContainsArrayPredicate()
+        {
+            ISqlGenerator<User> userSqlGenerator = new SqlGenerator<User>(_sqlConnector, true);
+            var ids = new int[] { };
+            var sqlQuery = userSqlGenerator.GetSelectAll(x => ids.Contains(x.Id));
+
+            Assert.Equal("SELECT [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[OfficePhoneId], [Users].[Deleted], [Users].[UpdatedAt] " +
+                         "FROM [Users] WHERE ([Users].[Id] IN @Id_p0) AND [Users].[Deleted] != 1", sqlQuery.GetSql());
+        }
+
+        [Fact]
         public static void NotContainsPredicate()
         {
             ISqlGenerator<User> userSqlGenerator = new SqlGenerator<User>(_sqlConnector, true);
@@ -408,35 +419,35 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
         [Fact]
         public static void SelectGroupConditionsWithPredicate()
         {
-            ISqlGenerator<Phone> userSqlGenerator = new SqlGenerator<Phone>(_sqlConnector, true);
+            ISqlGenerator<Phone> phoneSqlGenerator = new SqlGenerator<Phone>(_sqlConnector, true);
             var sPrefix = "SELECT [DAB].[Phones].[Id], [DAB].[Phones].[Number], [DAB].[Phones].[IsActive], [DAB].[Phones].[Code] FROM [DAB].[Phones] WHERE ";
 
-            var sqlQuery1 = userSqlGenerator.GetSelectAll(x => (x.IsActive && x.Id == 123) || (x.Id == 456 && x.Number == "456"));
+            var sqlQuery1 = phoneSqlGenerator.GetSelectAll(x => (x.IsActive && x.Id == 123) || (x.Id == 456 && x.Number == "456"));
             Assert.Equal(sPrefix + "([DAB].[Phones].[IsActive] = @IsActive_p0 AND [DAB].[Phones].[Id] = @Id_p1) OR ([DAB].[Phones].[Id] = @Id_p2 AND [DAB].[Phones].[Number] = @Number_p3)", sqlQuery1.GetSql());
 
-            var sqlQuery2 = userSqlGenerator.GetSelectAll(x => !x.IsActive || (x.Id == 456 && x.Number == "456"));
+            var sqlQuery2 = phoneSqlGenerator.GetSelectAll(x => !x.IsActive || (x.Id == 456 && x.Number == "456"));
             Assert.Equal(sPrefix + "[DAB].[Phones].[IsActive] = @IsActive_p0 OR ([DAB].[Phones].[Id] = @Id_p1 AND [DAB].[Phones].[Number] = @Number_p2)", sqlQuery2.GetSql());
 
-            var sqlQuery3 = userSqlGenerator.GetSelectAll(x => (x.Id == 456 && x.Number == "456") || x.Id == 123);
+            var sqlQuery3 = phoneSqlGenerator.GetSelectAll(x => (x.Id == 456 && x.Number == "456") || x.Id == 123);
             Assert.Equal(sPrefix + "([DAB].[Phones].[Id] = @Id_p0 AND [DAB].[Phones].[Number] = @Number_p1) OR [DAB].[Phones].[Id] = @Id_p2", sqlQuery3.GetSql());
 
-            var sqlQuery4 = userSqlGenerator.GetSelectAll(x => x.Number == "1" && (x.IsActive || x.Number == "456") && x.Id == 123);
+            var sqlQuery4 = phoneSqlGenerator.GetSelectAll(x => x.Number == "1" && (x.IsActive || x.Number == "456") && x.Id == 123);
             Assert.Equal(sPrefix + "[DAB].[Phones].[Number] = @Number_p0 AND ([DAB].[Phones].[IsActive] = @IsActive_p1 OR [DAB].[Phones].[Number] = @Number_p2) AND [DAB].[Phones].[Id] = @Id_p3", sqlQuery4.GetSql());
 
-            var sqlQuery5 = userSqlGenerator.GetSelectAll(x => x.Number == "1" && (x.IsActive || x.Number == "456" || x.Number == "678") && x.Id == 123);
+            var sqlQuery5 = phoneSqlGenerator.GetSelectAll(x => x.Number == "1" && (x.IsActive || x.Number == "456" || x.Number == "678") && x.Id == 123);
             Assert.Equal(sPrefix + "[DAB].[Phones].[Number] = @Number_p0 AND ([DAB].[Phones].[IsActive] = @IsActive_p1 OR [DAB].[Phones].[Number] = @Number_p2 OR [DAB].[Phones].[Number] = @Number_p3) AND [DAB].[Phones].[Id] = @Id_p4", sqlQuery5.GetSql());
 
             var ids = new List<int>();
-            var sqlQuery6 = userSqlGenerator.GetSelectAll(x => !x.IsActive || (x.IsActive && ids.Contains(x.Id)));
+            var sqlQuery6 = phoneSqlGenerator.GetSelectAll(x => !x.IsActive || (x.IsActive && ids.Contains(x.Id)));
             Assert.Equal(sPrefix + "[DAB].[Phones].[IsActive] = @IsActive_p0 OR ([DAB].[Phones].[IsActive] = @IsActive_p1 AND [DAB].[Phones].[Id] IN @Id_p2)", sqlQuery6.GetSql());
 
-            var sqlQuery7 = userSqlGenerator.GetSelectAll(x => (x.IsActive && x.Id == 123) && (x.Id == 456 && x.Number == "456"));
+            var sqlQuery7 = phoneSqlGenerator.GetSelectAll(x => (x.IsActive && x.Id == 123) && (x.Id == 456 && x.Number == "456"));
             Assert.Equal(sPrefix + "[DAB].[Phones].[IsActive] = @IsActive_p0 AND [DAB].[Phones].[Id] = @Id_p1 AND [DAB].[Phones].[Id] = @Id_p2 AND [DAB].[Phones].[Number] = @Number_p3", sqlQuery7.GetSql());
 
-            var sqlQuery8 = userSqlGenerator.GetSelectAll(x => x.Number == "1" && (x.IsActive || x.Number == "456" || x.Number == "123" || (x.Id == 1213 && x.Number == "678")) && x.Id == 123);
+            var sqlQuery8 = phoneSqlGenerator.GetSelectAll(x => x.Number == "1" && (x.IsActive || x.Number == "456" || x.Number == "123" || (x.Id == 1213 && x.Number == "678")) && x.Id == 123);
             Assert.Equal(sPrefix + "[DAB].[Phones].[Number] = @Number_p0 AND ([DAB].[Phones].[IsActive] = @IsActive_p1 OR [DAB].[Phones].[Number] = @Number_p2 OR [DAB].[Phones].[Number] = @Number_p3 OR ([DAB].[Phones].[Id] = @Id_p4 AND [DAB].[Phones].[Number] = @Number_p5)) AND [DAB].[Phones].[Id] = @Id_p6", sqlQuery8.GetSql());
 
-            var sqlQuery9 = userSqlGenerator.GetSelectAll(x => (x.Id == 456 && x.Number == "456") && x.Id == 123 && (x.Id == 4567 && x.Number == "4567"));
+            var sqlQuery9 = phoneSqlGenerator.GetSelectAll(x => (x.Id == 456 && x.Number == "456") && x.Id == 123 && (x.Id == 4567 && x.Number == "4567"));
             Assert.Equal(sPrefix + "[DAB].[Phones].[Id] = @Id_p0 AND [DAB].[Phones].[Number] = @Number_p1 AND [DAB].[Phones].[Id] = @Id_p2 AND [DAB].[Phones].[Id] = @Id_p3 AND [DAB].[Phones].[Number] = @Number_p4", sqlQuery9.GetSql());
         }
 
@@ -455,6 +466,37 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
             var ids = new List<int>();
             var sqlQuery2 = userSqlGenerator.GetSelectFirst(x => x.Phone.Number != "123" && (x.Name != "abc" || !x.Phone.IsActive || !ids.Contains(x.PhoneId) || !ids.Contains(x.Phone.Id)) && (x.Name == "abc" || x.Phone.IsActive), user => user.Phone);
             Assert.Equal(sPrefix + "([Phones_PhoneId].[Number] != @PhoneNumber_p0 AND ([Users].[Name] != @Name_p1 OR [Phones_PhoneId].[IsActive] = @PhoneIsActive_p2 OR [Users].[PhoneId] NOT IN @PhoneId_p3 OR [Phones_PhoneId].[Id] NOT IN @PhoneId_p4) AND ([Users].[Name] = @Name_p5 OR [Phones_PhoneId].[IsActive] = @PhoneIsActive_p6)) AND [Users].[Deleted] != 1", sqlQuery2.GetSql());
+        }
+
+        #endregion
+
+        #region Support `like` syntax
+
+        [Fact]
+        public static void SelectLikeWithPredicate()
+        {
+            ISqlGenerator<Phone> phoneSqlGenerator1 = new SqlGenerator<Phone>(_sqlConnector, true);
+            var sPrefix1 = "SELECT [DAB].[Phones].[Id], [DAB].[Phones].[Number], [DAB].[Phones].[IsActive], [DAB].[Phones].[Code] FROM [DAB].[Phones] WHERE ";
+
+            var sqlQuery11 = phoneSqlGenerator1.GetSelectAll(x => x.Code.StartsWith("123", StringComparison.OrdinalIgnoreCase) || !x.Code.EndsWith("456") || x.Code.Contains("789"));
+            Assert.Equal(sPrefix1 + "[DAB].[Phones].[Code] LIKE @Code_p0 OR [DAB].[Phones].[Code] NOT LIKE @Code_p1 OR [DAB].[Phones].[Code] LIKE @Code_p2", sqlQuery11.GetSql());
+
+            var parameters11 = sqlQuery11.Param as IDictionary<string, object>;
+            Assert.True("123%" == parameters11["Code_p0"].ToString());
+            Assert.True("%456" == parameters11["Code_p1"].ToString());
+            Assert.True("%789%" == parameters11["Code_p2"].ToString());
+
+            ISqlGenerator<User> userSqlGenerator2 = new SqlGenerator<User>(_sqlConnector, true);
+            var sPrefix2 = "SELECT TOP 1 [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[OfficePhoneId], [Users].[Deleted], [Users].[UpdatedAt], " +
+            "[Phones_PhoneId].[Id], [Phones_PhoneId].[Number], [Phones_PhoneId].[IsActive], [Phones_PhoneId].[Code] " +
+            "FROM [Users] INNER JOIN [DAB].[Phones] AS [Phones_PhoneId] ON [Users].[PhoneId] = [Phones_PhoneId].[Id] " +
+            "WHERE ";
+
+            var sqlQuery21 = userSqlGenerator2.GetSelectFirst(x => x.Phone.Number.StartsWith("123") || (!x.Name.Contains("abc") && x.Phone.IsActive), user => user.Phone);
+            Assert.Equal(sPrefix2 + "([Phones_PhoneId].[Number] LIKE @PhoneNumber_p0 OR ([Users].[Name] NOT LIKE @Name_p1 AND [Phones_PhoneId].[IsActive] = @PhoneIsActive_p2)) AND [Users].[Deleted] != 1", sqlQuery21.GetSql());
+            var parameters21 = sqlQuery21.Param as IDictionary<string, object>;
+            Assert.True("123%" == parameters21["PhoneNumber_p0"].ToString());
+            Assert.True("%abc%" == parameters21["Name_p1"].ToString());
         }
 
         #endregion


### PR DESCRIPTION
1. Support `LIKE` syntax
```csharp
user.FindAll(x => x.Name.Contains("Hello")); //WHERE Name LIKE @Name_p0, @Name_p0=%Hello%
user.FindAll(x => !x.Name.StartsWith("Hello")); //WHERE Name NOT LIKE @Name_p0, @Name_p0=Hello%
user.FindAll(x => x.Name.EndsWith("Hello")); //WHERE Name LIKE @Name_p0, @Name_p0=%Hello
```

 2. Support Array `Contains` syntax
```csharp
var ids = new int[] { 1, 2, 3};
user.FindAll(x => ids.Contains(x.Id)); //WHERE Id IN @Id_p0
```
